### PR TITLE
修复bug ,IDGen 实例避免重复创建

### DIFF
--- a/src/main/java/io/opensharding/keygen/leaf/LeafSnowflakeKeyGenerator.java
+++ b/src/main/java/io/opensharding/keygen/leaf/LeafSnowflakeKeyGenerator.java
@@ -36,7 +36,7 @@ public final class LeafSnowflakeKeyGenerator implements ShardingKeyGenerator {
     @Setter
     private Properties properties;
 
-    private IDGen idGen;
+    private volatile IDGen idGen;
 
     @Override
     public Comparable<?> generateKey() {


### PR DESCRIPTION
双重校验单例模式需要加volatile来避免单例重复创建